### PR TITLE
feat: Choose which settings to sync

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,7 +9,7 @@
       "eslint:recommended",
       "plugin:@typescript-eslint/eslint-recommended",
       "plugin:@typescript-eslint/recommended"
-    ], 
+    ],
     "parserOptions": {
         "sourceType": "module"
     },
@@ -18,6 +18,7 @@
       "@typescript-eslint/no-unused-vars": ["error", { "args": "none" }],
       "@typescript-eslint/ban-ts-comment": "off",
       "no-prototype-builtins": "off",
-      "@typescript-eslint/no-empty-function": "off"
-    } 
+      "@typescript-eslint/no-empty-function": "off",
+      "no-case-declarations": "off"
+    }
   }

--- a/src/ProfileModal.ts
+++ b/src/ProfileModal.ts
@@ -41,11 +41,11 @@ export class ProfileModal extends SuggestModal<SettingsProfileSuggestion> {
     // Returns all available suggestions.
     getSuggestions(query: string): SettingsProfileSuggestion[] {
         // Get all matching SettingsProfiles
-        let profiles = this.plugin.settings.profilesList.filter((profile) =>
+        const profiles = this.plugin.settings.profilesList.filter((profile) =>
             profile.name.toLowerCase().includes(query.toLowerCase())
         );
         // Expand SettingsProfile to SettingsProfileSuggestion
-        let suggestions: SettingsProfileSuggestion[] = [];
+        const suggestions: SettingsProfileSuggestion[] = [];
         profiles.forEach(profile => {
             suggestions.push({
                 ...profile,
@@ -64,12 +64,12 @@ export class ProfileModal extends SuggestModal<SettingsProfileSuggestion> {
 
     // Renders each suggestion item.
     renderSuggestion(suggestion: SettingsProfileSuggestion, el: HTMLElement) {
-        // Create Item 
+        // Create Item
         el.addClass("mod-complex");
-        let content = el.createEl("div", { cls: "suggestion-content" });
+        const content = el.createEl("div", { cls: "suggestion-content" });
         content.createEl("div", { cls: "suggestion-title" })
             .createEl("span", { text: suggestion.name })
-        // Profile not existing 
+        // Profile not existing
         if (suggestion.state === ProfileState.NEW) {
             content.parentElement?.createEl("div", { cls: "suggestion-aux" })
                 .createEl("span", { text: "Enter to create", cls: "suggestion-hotkey" })
@@ -84,7 +84,7 @@ export class ProfileModal extends SuggestModal<SettingsProfileSuggestion> {
     // Perform action on the selected suggestion.
     onChooseSuggestion(suggestion: SettingsProfileSuggestion, evt: MouseEvent | KeyboardEvent) {
         // Trim SettingsProfileSuggestion to SettingsProfile
-        const { state: state, ...rest } = suggestion;
+        const { state, ...rest } = suggestion;
         const profile: SettingsProfile = { ...rest };
         // Submit profile
         this.onSubmit(profile, state);

--- a/src/ProfileModal.ts
+++ b/src/ProfileModal.ts
@@ -1,4 +1,4 @@
-import { App, SuggestModal } from "obsidian";
+import { App, Modal, Notice, Setting, SuggestModal } from "obsidian";
 import SettingsProfilesPlugin from "./main";
 import { SettingsProfile } from "./Settings";
 
@@ -56,7 +56,14 @@ export class ProfileModal extends SuggestModal<SettingsProfileSuggestion> {
         if (suggestions.length <= 0) {
             suggestions.push({
                 name: query,
-                state: ProfileState.NEW
+                state: ProfileState.NEW,
+                appearance: true,
+                app: true,
+                bookmarks: true,
+                communityPlugins: true,
+                corePlugins: true,
+                graph: true,
+                hotkeys: true,
             })
         }
         return suggestions
@@ -88,5 +95,141 @@ export class ProfileModal extends SuggestModal<SettingsProfileSuggestion> {
         const profile: SettingsProfile = { ...rest };
         // Submit profile
         this.onSubmit(profile, state);
+    }
+}
+
+export class AddProfileModal extends Modal {
+    name: string;
+    plugin: SettingsProfilesPlugin;
+    onSubmit: (name: string) => void;
+
+    constructor(app: App, plugin: SettingsProfilesPlugin, onSubmit: (name: string) => void) {
+        super(app);
+        this.plugin = plugin;
+        this.onSubmit = onSubmit;
+    }
+
+    onOpen(): void {
+        const {contentEl} = this;
+        contentEl.createEl("h2", {text: "Profile Name"});
+
+        new Setting(contentEl)
+            .setClass("settings-profiles-modal")
+            .addText(text => text
+                .setPlaceholder("Default")
+                .onChange((value) => {
+                    this.name = value;
+                }));
+
+        new Setting(contentEl)
+            .addButton(button => button
+                .setButtonText("Create Profile")
+                .onClick(() => {
+                    if (!this.name) {
+                        new Notice("Please enter a name!");
+                        return;
+                    } else if (this.plugin.settings.profilesList.find(value => value.name === this.name)) {
+                        new Notice("Profile already exists!");
+                        return;
+                    }
+                    this.onSubmit(this.name);
+                    this.close();
+                }));
+    }
+    onClose(): void {
+        const {contentEl} = this;
+        contentEl.empty();
+    }
+}
+
+export class ChooseSettingsToSync extends Modal {
+    profile: SettingsProfile;
+    plugin: SettingsProfilesPlugin;
+    onSubmit: (profile: SettingsProfile) => void;
+
+    constructor(app: App, plugin: SettingsProfilesPlugin, profile: SettingsProfile, onSubmit: (profile: SettingsProfile) => void) {
+        super(app);
+        this.plugin = plugin;
+        this.profile = profile;
+        this.onSubmit = onSubmit;
+    }
+
+    onOpen(): void {
+        const {contentEl} = this;
+        contentEl.createEl("h2", {text: "Settings to enable"});
+        contentEl.createEl("p", {text: "Choose which settings to enable when switching to this profile. Obsidian will keep the actual settings when switching if they are disabled. Enable allow configure different settings per profile."});
+
+        new Setting(contentEl)
+            .setName("Appareance")
+            .addToggle(toggle => toggle
+                .setValue(this.profile.appearance ?? true)
+                .onChange((value) => {
+                    this.profile.appearance = value;
+                }));
+
+
+        new Setting(contentEl)
+            .setName("App")
+            .addToggle(toggle => toggle
+                .setValue(this.profile.app ?? true)
+                .onChange((value) => {
+                    this.profile.app = value;
+                }));
+
+        new Setting(contentEl)
+            .setName("Bookmarks")
+            .addToggle(toggle => toggle
+                .setValue(this.profile.bookmarks ?? true)
+                .onChange((value) => {
+                    this.profile.bookmarks = value;
+                }));
+
+        new Setting(contentEl)
+            .setName("Community Plugins")
+            .setDesc("Sync the plugin community list")
+            .addToggle(toggle => toggle
+                .setValue(this.profile.communityPlugins ?? true)
+                .onChange((value) => {
+                    this.profile.communityPlugins = value;
+                }));
+
+        new Setting(contentEl)
+            .setName("Core Plugins")
+            .setDesc("Sync enabled core plugins")
+            .addToggle(toggle => toggle
+                .setValue(this.profile.corePlugins ?? true)
+                .onChange((value) => {
+                    this.profile.corePlugins = value;
+                }));
+
+        new Setting(contentEl)
+            .setName("Graph")
+            .setDesc("Sync the graph view settings")
+            .addToggle(toggle => toggle
+                .setValue(this.profile.graph ?? true)
+                .onChange((value) => {
+                    this.profile.graph = value;
+                }));
+
+        new Setting(contentEl)
+            .setName("Hotkeys")
+            .addToggle(toggle => toggle
+                .setValue(this.profile.hotkeys ?? true)
+                .onChange((value) => {
+                    this.profile.hotkeys = value;
+                }));
+
+        new Setting(contentEl)
+            .setName("Submit")
+            .addButton(button => button
+                .setButtonText("Submit")
+                .onClick(() => {
+                    this.onSubmit(this.profile);
+                    this.close();
+                }));
+    }
+    onClose(): void {
+        const {contentEl} = this;
+        contentEl.empty();
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,15 @@
-/*
+.settings-profiles-modal .setting-item-info {
+	display: none;
+}
 
-This CSS file will be included with your plugin, and
-available in the app when your plugin is enabled.
+.settings-profiles-modal input {
+	width: 100%;
+}
 
-If your plugin does not need CSS, delete this file.
+.settings-profiles-current .setting-item-name {
+	font-weight: bold;
+}
 
-*/
+.settings-profiles-current .setting-item-name::before {
+	content: "⭐";
+}


### PR DESCRIPTION
- Edited settings to add a list for each profile
- Enabled profil will be in bold + have a star
- Added "play" button to enable profil 
- Added trash to delete profil from settings (it won't delete the folder in the targetPath. Dunno if it's a good idea to delete it?)
![image](https://github.com/4Source/SettingsProfiles-Obsidian-Plugin/assets/30244939/f5864bd1-fa3e-4e83-b81d-2fa2d8bda54c)

- Clicking on 'add profile' will open a modal. Checking if already existing profile throw an error.
- Added new interface per profile ; each file used by obsidian have their settings
- Enable/disable allow to keep different settings per profile in sync. 
	- If disabled: file won't be created in the profile folder, it will use the "already existing file" from Obsidian. Consequence:  sync (keep new version) will be disabled (as it always use the registered obsidian settings).
	- If enabled : File will be created and used when switching profile. Disabled file will be skipped.

Aka: allow to keep specific settings per profile. If I disable everything and keep only appeareance, I can have different appeareance for profile, but keeping the same obsidian hotkeys for all. 